### PR TITLE
C7-166: Hotfix - Ajustar tamaño de opciones en sección Perfil Laboral de formulario work_profile

### DIFF
--- a/src/components/Form/FormWorkProfile/style.scss
+++ b/src/components/Form/FormWorkProfile/style.scss
@@ -52,7 +52,7 @@
     max-height: 120px;
     margin-left: 15px;
     margin-bottom: 15px;
-    width: 760px;
+    width: 75vw;
     overflow-y: auto;
     overflow-x: hidden;
     gap: 0px;
@@ -76,7 +76,7 @@
       margin-left: 12px;
     }
     &-danger {
-      margin-left: auto;
+      margin-left: 2vw;
     }
   }
 }


### PR DESCRIPTION
ahora muestran un tamaño mas acorde:
![image](https://github.com/dlab-team/c7-frontend/assets/77648181/ff350175-b83b-414a-ab60-c841925cc1c3)
